### PR TITLE
setupProject no longer sets up Python virtual environment

### DIFF
--- a/.github/workflows/examples-SK.yaml
+++ b/.github/workflows/examples-SK.yaml
@@ -38,8 +38,9 @@ jobs:
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
       # 2025-01-30: systemfonts R package failed to install due to these missing
+      # 2025-04-15: error also observed on release
       - name: Install extra Linux dependencies
-        if: runner.os == 'Linux' && matrix.config.r == 'devel'
+        if: runner.os == 'Linux'
         run: |
           sudo apt -y install libfontconfig1-dev
           sudo apt-get install libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -39,8 +39,9 @@ jobs:
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
       # 2025-01-30: systemfonts R package failed to install due to these missing
+      # 2025-04-15: error also observed on release
       - name: Install extra Linux dependencies
-        if: runner.os == 'Linux' && matrix.config.r == 'devel'
+        if: runner.os == 'Linux'
         run: |
           sudo apt -y install libfontconfig1-dev
           sudo apt-get install libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev

--- a/examples/SK-small_1998-2000.R
+++ b/examples/SK-small_1998-2000.R
@@ -40,33 +40,7 @@
     ),
 
     # Set packages required for set up
-    require = c("PredictiveEcology/CBMutils@development (>=2.0)", "reticulate",
-                "reproducible", "terra"),
-
-    # Set up Python
-    ret = {
-      reticulate::virtualenv_create(
-        "r-spadesCBM",
-        python = if (!reticulate::virtualenv_exists("r-spadesCBM")){
-          CBMutils::ReticulateFindPython(
-            version        = ">=3.9,<=3.12.7",
-            versionInstall = "3.10:latest"
-          )
-        },
-        packages = c(
-          "numpy<2",
-          "pandas>=1.1.5",
-          "scipy",
-          "numexpr>=2.8.7",
-          "numba",
-          "pyyaml",
-          "mock",
-          "openpyxl",
-          "libcbm"
-        )
-      )
-      reticulate::use_virtualenv("r-spadesCBM")
-    },
+    require = c("reproducible", "terra"),
 
     # Set input: Study area
     masterRaster = {

--- a/examples/SK_1985-2011.R
+++ b/examples/SK_1985-2011.R
@@ -39,34 +39,6 @@
       spades.moduleCodeChecks = FALSE
     ),
 
-    # Set packages required for set up
-    require = c("PredictiveEcology/CBMutils@development (>=2.0)", "reticulate"),
-
-    # Set up Python
-    ret = {
-      reticulate::virtualenv_create(
-        "r-spadesCBM",
-        python = if (!reticulate::virtualenv_exists("r-spadesCBM")){
-          CBMutils::ReticulateFindPython(
-            version        = ">=3.9,<=3.12.7",
-            versionInstall = "3.10:latest"
-          )
-        },
-        packages = c(
-          "numpy<2",
-          "pandas>=1.1.5",
-          "scipy",
-          "numexpr>=2.8.7",
-          "numba",
-          "pyyaml",
-          "mock",
-          "openpyxl",
-          "libcbm"
-        )
-      )
-      reticulate::use_virtualenv("r-spadesCBM")
-    },
-
     # Set input: Output table
     outputs = as.data.frame(expand.grid(
       objectName = c("cbmPools", "NPP"),

--- a/globalSK.R
+++ b/globalSK.R
@@ -26,8 +26,7 @@ out <- SpaDES.project::setupProject(
                "PredictiveEcology/CBM_vol2biomass@development",
                "PredictiveEcology/CBM_core@development"),
   times = times,
-  require = c("PredictiveEcology/CBMutils@development (>=2.0)", "reticulate",
-              "reproducible"),
+  require = c("reproducible"),
 
   params = list(
     CBM_defaults = list(
@@ -41,34 +40,10 @@ out <- SpaDES.project::setupProject(
     )
   ),
 
-  ret = {
-    reticulate::virtualenv_create(
-      "r-spadesCBM",
-      python = if (!reticulate::virtualenv_exists("r-spadesCBM")){
-        CBMutils::ReticulateFindPython(
-          version        = ">=3.9,<=3.12.7",
-          versionInstall = "3.10:latest"
-        )
-      },
-      packages = c(
-        "numpy<2",
-        "pandas>=1.1.5",
-        "scipy",
-        "numexpr>=2.8.7",
-        "numba",
-        "pyyaml",
-        "mock",
-        "openpyxl",
-        "libcbm"
-      )
-    )
-    reticulate::use_virtualenv("r-spadesCBM")
-  },
-
   #### begin manually passed inputs #########################################
   ## define the  study area.
   masterRaster = {
-    mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1zUyFH8k6Ef4c_GiWMInKbwAl6m6gvLJW/view?usp=drive_link",
+    mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1zUyFH8k6Ef4c_GiWMInKbwAl6m6gvLJW",
                                    destinationPath = "inputs")
     mr[mr[] == 0] <- NA
     mr
@@ -76,12 +51,10 @@ out <- SpaDES.project::setupProject(
 
   disturbanceRastersURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt",
 
-  outputs = as.data.frame(expand.grid(objectName = c("cbmPools", "NPP"),
-                                      saveTime = sort(c(times$start,
-                                                        times$start +
-                                                          c(1:(times$end - times$start))
-                                      )))),
-
+  outputs = as.data.frame(expand.grid(
+    objectName = c("cbmPools", "NPP"),
+    saveTime = sort(c(times$start, times$start + c(1:(times$end - times$start))))
+  ))
 )
 
 # Run

--- a/globalSKsmall.R
+++ b/globalSKsmall.R
@@ -26,8 +26,7 @@ out <- SpaDES.project::setupProject(
                "PredictiveEcology/CBM_vol2biomass@development",
                "PredictiveEcology/CBM_core@development"),
   times = times,
-  require = c("PredictiveEcology/CBMutils@development (>=2.0)", "reticulate",
-              "terra", "reproducible"),
+  require = c("terra", "reproducible"),
 
   params = list(
     CBM_defaults = list(
@@ -40,31 +39,6 @@ out <- SpaDES.project::setupProject(
       .useCache = TRUE
     )
   ),
-  functions = "PredictiveEcology/CBM_core@training/R/ReticulateFindPython.R",
-
-  ret = {
-    reticulate::virtualenv_create(
-      "r-spadesCBM",
-      python = if (!reticulate::virtualenv_exists("r-spadesCBM")){
-        CBMutils::ReticulateFindPython(
-          version        = ">=3.9,<=3.12.7",
-          versionInstall = "3.10:latest"
-        )
-      },
-      packages = c(
-        "numpy<2",
-        "pandas>=1.1.5",
-        "scipy",
-        "numexpr>=2.8.7",
-        "numba",
-        "pyyaml",
-        "mock",
-        "openpyxl",
-        "libcbm"
-      )
-    )
-    reticulate::use_virtualenv("r-spadesCBM")
-  },
 
   #### begin manually passed inputs #########################################
   ## define the  study area.
@@ -73,7 +47,7 @@ out <- SpaDES.project::setupProject(
     masterRaster <- terra::rast(extent, res = 30)
     terra::crs(masterRaster) <- "PROJCRS[\"Lambert_Conformal_Conic_2SP\",\n    BASEGEOGCRS[\"GCS_GRS_1980_IUGG_1980\",\n        DATUM[\"D_unknown\",\n            ELLIPSOID[\"GRS80\",6378137,298.257222101,\n                LENGTHUNIT[\"metre\",1,\n                    ID[\"EPSG\",9001]]]],\n        PRIMEM[\"Greenwich\",0,\n            ANGLEUNIT[\"degree\",0.0174532925199433,\n                ID[\"EPSG\",9122]]]],\n    CONVERSION[\"Lambert Conic Conformal (2SP)\",\n        METHOD[\"Lambert Conic Conformal (2SP)\",\n            ID[\"EPSG\",9802]],\n        PARAMETER[\"Latitude of false origin\",49,\n            ANGLEUNIT[\"degree\",0.0174532925199433],\n            ID[\"EPSG\",8821]],\n        PARAMETER[\"Longitude of false origin\",-95,\n            ANGLEUNIT[\"degree\",0.0174532925199433],\n            ID[\"EPSG\",8822]],\n        PARAMETER[\"Latitude of 1st standard parallel\",49,\n            ANGLEUNIT[\"degree\",0.0174532925199433],\n            ID[\"EPSG\",8823]],\n        PARAMETER[\"Latitude of 2nd standard parallel\",77,\n            ANGLEUNIT[\"degree\",0.0174532925199433],\n            ID[\"EPSG\",8824]],\n        PARAMETER[\"Easting at false origin\",0,\n            LENGTHUNIT[\"metre\",1],\n            ID[\"EPSG\",8826]],\n        PARAMETER[\"Northing at false origin\",0,\n            LENGTHUNIT[\"metre\",1],\n            ID[\"EPSG\",8827]]],\n    CS[Cartesian,2],\n        AXIS[\"easting\",east,\n            ORDER[1],\n            LENGTHUNIT[\"metre\",1,\n                ID[\"EPSG\",9001]]],\n        AXIS[\"northing\",north,\n            ORDER[2],\n            LENGTHUNIT[\"metre\",1,\n                ID[\"EPSG\",9001]]]]"
     masterRaster[] <- rep(1, terra::ncell(masterRaster))
-    mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1zUyFH8k6Ef4c_GiWMInKbwAl6m6gvLJW/view?usp=drive_link",
+    mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1zUyFH8k6Ef4c_GiWMInKbwAl6m6gvLJW",
                                    destinationPath = "inputs",
                                    to = masterRaster,
                                    method = "near")
@@ -83,12 +57,10 @@ out <- SpaDES.project::setupProject(
 
   disturbanceRastersURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt",
 
-  outputs = as.data.frame(expand.grid(objectName = c("cbmPools", "NPP"),
-                                      saveTime = sort(c(times$start,
-                                                        times$start +
-                                                          c(1:(times$end - times$start))
-                                      )))),
-
+  outputs = as.data.frame(expand.grid(
+    objectName = c("cbmPools", "NPP"),
+    saveTime = sort(c(times$start, times$start + c(1:(times$end - times$start))))
+  ))
 )
 
 # Run

--- a/tests/testthat/test-SK-small_t1-1998-2000.R
+++ b/tests/testthat/test-SK-small_t1-1998-2000.R
@@ -33,33 +33,7 @@ test_that("SK-small 1998-2000", {
         outputPath  = file.path(projectPath, "outputs")
       ),
 
-      require = c("PredictiveEcology/CBMutils@development (>=2.0)", "reticulate",
-                  "terra", "reproducible"),
-
-      ret = {
-
-        reticulate::virtualenv_create(
-          "r-spadesCBM",
-          python = if (!reticulate::virtualenv_exists("r-spadesCBM")){
-            CBMutils::ReticulateFindPython(
-              version        = ">=3.9,<=3.12.7",
-              versionInstall = "3.10:latest"
-            )
-          },
-          packages = c(
-            "numpy<2",
-            "pandas>=1.1.5",
-            "scipy",
-            "numexpr>=2.8.7",
-            "numba",
-            "pyyaml",
-            "mock",
-            "openpyxl",
-            "libcbm"
-          )
-        )
-        reticulate::use_virtualenv("r-spadesCBM")
-      },
+      require = c("terra", "reproducible"),
 
       masterRaster = {
         extent = terra::ext(c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183))

--- a/tests/testthat/test-SK-small_t2-1985-2011.R
+++ b/tests/testthat/test-SK-small_t2-1985-2011.R
@@ -33,33 +33,7 @@ test_that("SK-small 1985-2011", {
         outputPath  = file.path(projectPath, "outputs")
       ),
 
-      require = c("PredictiveEcology/CBMutils@development (>=2.0)", "reticulate",
-                  "terra", "reproducible"),
-
-      ret = {
-
-        reticulate::virtualenv_create(
-          "r-spadesCBM",
-          python = if (!reticulate::virtualenv_exists("r-spadesCBM")){
-            CBMutils::ReticulateFindPython(
-              version        = ">=3.9,<=3.12.7",
-              versionInstall = "3.10:latest"
-            )
-          },
-          packages = c(
-            "numpy<2",
-            "pandas>=1.1.5",
-            "scipy",
-            "numexpr>=2.8.7",
-            "numba",
-            "pyyaml",
-            "mock",
-            "openpyxl",
-            "libcbm"
-          )
-        )
-        reticulate::use_virtualenv("r-spadesCBM")
-      },
+      require = c("terra", "reproducible"),
 
       masterRaster = {
         extent = terra::ext(c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183))

--- a/tests/testthat/test-SK_t1-1998-2000.R
+++ b/tests/testthat/test-SK_t1-1998-2000.R
@@ -33,33 +33,6 @@ test_that("SK 1998-2000", {
         outputPath  = file.path(projectPath, "outputs")
       ),
 
-      require = c("PredictiveEcology/CBMutils@development (>=2.0)", "reticulate"),
-
-      ret = {
-
-        reticulate::virtualenv_create(
-          "r-spadesCBM",
-          python = if (!reticulate::virtualenv_exists("r-spadesCBM")){
-            CBMutils::ReticulateFindPython(
-              version        = ">=3.9,<=3.12.7",
-              versionInstall = "3.10:latest"
-            )
-          },
-          packages = c(
-            "numpy<2",
-            "pandas>=1.1.5",
-            "scipy",
-            "numexpr>=2.8.7",
-            "numba",
-            "pyyaml",
-            "mock",
-            "openpyxl",
-            "libcbm"
-          )
-        )
-        reticulate::use_virtualenv("r-spadesCBM")
-      },
-
       outputs = as.data.frame(expand.grid(
         objectName = c("cbmPools", "NPP"),
         saveTime   = sort(c(times$start, times$start + c(1:(times$end - times$start))))

--- a/tests/testthat/test-SK_t2-1985-2011.R
+++ b/tests/testthat/test-SK_t2-1985-2011.R
@@ -33,33 +33,6 @@ test_that("SK 1985-2011", {
         outputPath  = file.path(projectPath, "outputs")
       ),
 
-      require = c("PredictiveEcology/CBMutils@development (>=2.0)", "reticulate"),
-
-      ret = {
-
-        reticulate::virtualenv_create(
-          "r-spadesCBM",
-          python = if (!reticulate::virtualenv_exists("r-spadesCBM")){
-            CBMutils::ReticulateFindPython(
-              version        = ">=3.9,<=3.12.7",
-              versionInstall = "3.10:latest"
-            )
-          },
-          packages = c(
-            "numpy<2",
-            "pandas>=1.1.5",
-            "scipy",
-            "numexpr>=2.8.7",
-            "numba",
-            "pyyaml",
-            "mock",
-            "openpyxl",
-            "libcbm"
-          )
-        )
-        reticulate::use_virtualenv("r-spadesCBM")
-      },
-
       outputs = as.data.frame(expand.grid(
         objectName = c("cbmPools", "NPP"),
         saveTime   = sort(c(times$start, times$start + c(1:(times$end - times$start))))


### PR DESCRIPTION
`setupProject` no longer sets up Python virtual environment after the PR where it is done instead in `CBM_core`: https://github.com/PredictiveEcology/CBM_core/pull/53

Let's watch that all the GHA pass here. Then we should be OK to merge everything to main (@camillegiuliano).

Marked as a draft until CBM_core PR is merged in.