### PR TITLE
masterRasters created manually with terra::rast

### DIFF
--- a/examples/SK-small_1998-2000.R
+++ b/examples/SK-small_1998-2000.R
@@ -43,36 +43,18 @@
     ),
 
     # Set packages required for set up
-    require = c("reproducible", "terra"),
+    require = "terra",
 
     # Set input: Study area
-    masterRaster = {
-
-      # Set study area extent and resolution
-      mrAOI <- list(
-        ext = c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183),
-        res = 30
-      )
-
-      # Align SK master raster with study area
-      mrSource <- terra::rast(
-        reproducible::preProcess(
-          destinationPath = "~/spadesCBM/inputs",
-          url             = "https://drive.google.com/file/d/1zUyFH8k6Ef4c_GiWMInKbwAl6m6gvLJW",
-          targetFile      = "ldSp_TestArea.tif"
-        )$targetFilePath)
-
-      reproducible::postProcess(
-        mrSource,
-        to = terra::rast(
-          extent     = mrAOI$ext,
-          resolution = mrAOI$res,
-          crs        = terra::crs(mrSource),
-          vals       = 1
-        ),
-        method = "near"
-      ) |> terra::classify(cbind(0, NA))
-    },
+    masterRaster = terra::rast(
+      crs  = "EPSG:3979",
+      res  = 30,
+      vals = 1L,
+      xmin = -690643.4762,
+      xmax = -632143.4762,
+      ymin =  700447.9315,
+      ymax =  757447.9315
+    ),
 
     # NTEMS disturbances sample
     disturbanceRastersURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt",

--- a/globalSK.R
+++ b/globalSK.R
@@ -32,7 +32,6 @@ out <- SpaDES.project::setupProject(
                "PredictiveEcology/CBM_vol2biomass_SK@development",
                "PredictiveEcology/CBM_core@development"),
   times = times,
-  require = c("reproducible"),
 
   params = list(
     CBM_defaults = list(
@@ -47,14 +46,20 @@ out <- SpaDES.project::setupProject(
   ),
 
   #### begin manually passed inputs #########################################
-  ## define the  study area.
-  masterRaster = {
-    mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1FmtbEKbkzufIifETONxOkoplGX50lrT_",
-                                   destinationPath = "inputs")
-    mr[mr[] == 0] <- NA
-    mr
-  },
+  require = "terra",
 
+  # Set study area
+  masterRaster = terra::rast(
+    crs  = "EPSG:3979",
+    res  = 30,
+    vals = 1L,
+    xmin = -1077673.4762,
+    xmax =  -426673.4762,
+    ymin =   108487.9315,
+    ymax =   971077.9315
+  ),
+
+  # Set disturbances data source
   disturbanceSource = "NTEMS"
 )
 

--- a/globalSKsmall.R
+++ b/globalSKsmall.R
@@ -32,7 +32,6 @@ out <- SpaDES.project::setupProject(
                "PredictiveEcology/CBM_vol2biomass_SK@development",
                "PredictiveEcology/CBM_core@development"),
   times = times,
-  require = c("terra", "reproducible"),
 
   params = list(
     CBM_defaults = list(
@@ -47,14 +46,20 @@ out <- SpaDES.project::setupProject(
   ),
 
   #### begin manually passed inputs #########################################
-  ## define the  study area.
-  masterRaster = {
-    mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1zUyFH8k6Ef4c_GiWMInKbwAl6m6gvLJW",
-                                   destinationPath = "inputs")
-    mr[mr[] == 0] <- NA
-    mr
-  },
+  require = "terra",
 
+  # Set study area
+  masterRaster = terra::rast(
+    crs  = "EPSG:3979",
+    res  = 30,
+    vals = 1L,
+    xmin = -690643.4762,
+    xmax = -632143.4762,
+    ymin =  700447.9315,
+    ymax =  757447.9315
+  ),
+
+  # Set disturbances data source: NTEMS disturbances sample
   disturbanceRastersURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt"
 )
 

--- a/tests/testthat/test-SK_1-small_1998-2000.R
+++ b/tests/testthat/test-SK_1-small_1998-2000.R
@@ -35,9 +35,12 @@ test_that("SK-small 1998-2000", {
       # Small test area in SPU 27
       masterRaster = terra::rast(
         crs  = "EPSG:3979",
-        ext  = c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183),
         res  = 30,
-        vals = 1L
+        vals = 1L,
+        xmin = -690643.4762,
+        xmax = -632143.4762,
+        ymin =  700447.9315,
+        ymax =  757447.9315
       ),
 
       # NTEMS disturbances sample

--- a/tests/testthat/test-SK_2-SPU-27-28_NTEMS_1998-2000.R
+++ b/tests/testthat/test-SK_2-SPU-27-28_NTEMS_1998-2000.R
@@ -35,9 +35,12 @@ test_that("SK-med with NTEMS disturbances 1998-2000", {
       # Test area covering SPU 27 & 28
       masterRaster = terra::rast(
         crs  = "EPSG:3979",
-        ext  = c(xmin = -710000, xmax = -640000, ymin = 690000, ymax = 760000),
         res  = 50,
-        vals = 1L
+        vals = 1L,
+        xmin = -710000,
+        xmax = -640000,
+        ymin =  690000,
+        ymax =  760000
       ),
 
       # NTEMS disturbances


### PR DESCRIPTION
Similar to https://github.com/PredictiveEcology/CBM_dataPrep_SK/pull/65

globalSK.R and globalSKsmall.R have been updated to use masterRasters that have all non-NA values.

For globalSK.R the masterRaster geometry has been duplicated from the URL input. For globalSKsmall.R, the geometry has been updated slightly: we were using the old "ldSp_TestArea.tif" input raster with the 29.99072mx29.9885m resolution here. I've replaced this with a crop of our full SK default masterRaster that covers the same area at 30mx30m only aligned with our new grid. This will make running this faster as most default inputs are already aligned to this grid.