### PR TITLE
Globals clean-up

### DIFF
--- a/globalSK-SCANFI-CBMsources.R
+++ b/globalSK-SCANFI-CBMsources.R
@@ -1,6 +1,7 @@
 projectPath <- "~/GitHub/spadesCBM"
-repos <- unique(c("predictiveecology.r-universe.dev", getOption("repos")))
-install.packages("SpaDES.project", repos = repos)
+
+# Install SpaDES.project
+install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
 
 # Set times
 times <- list(start = 1985, end = 2020)
@@ -18,7 +19,7 @@ projSetup <- SpaDES.project::setupProject(
                cachePath   = file.path(projectPath, "cache")),
 
   options = options(
-    repos = c(repos = repos),
+    repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))),
     Require.cloneFrom = Sys.getenv("R_LIBS_USER"),
     ## These are for speed
     reproducible.useMemoise = FALSE,

--- a/globalSK-SCANFI-CBMsources.R
+++ b/globalSK-SCANFI-CBMsources.R
@@ -1,7 +1,9 @@
-projectPath <- "~/GitHub/spadesCBM"
 
 # Install SpaDES.project
 install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
+
+# Set project path
+projectPath <- "~/GitHub/spadesCBM"
 
 # Set times
 times <- list(start = 1985, end = 2020)

--- a/globalSK-SCANFI.R
+++ b/globalSK-SCANFI.R
@@ -1,7 +1,7 @@
 projectPath <- "~/GitHub/spadesCBM"
-repos <- unique(c("predictiveecology.r-universe.dev", getOption("repos")))
-install.packages("SpaDES.project",
-                 repos = repos)
+
+# Install SpaDES.project
+install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
 
 # Set times
 times <- list(start = 1985, end = 2020)
@@ -18,7 +18,7 @@ out <- SpaDES.project::setupProject(
                cachePath   = file.path(projectPath, "cache")),
 
   options = options(
-    repos = c(repos = repos),
+    repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))),
     Require.cloneFrom = Sys.getenv("R_LIBS_USER"),
     ## These are for speed
     reproducible.useMemoise = TRUE,

--- a/globalSK-SCANFI.R
+++ b/globalSK-SCANFI.R
@@ -3,7 +3,7 @@ repos <- unique(c("predictiveecology.r-universe.dev", getOption("repos")))
 install.packages("SpaDES.project",
                  repos = repos)
 
-# start in 1998, and end in 2000
+# Set times
 times <- list(start = 1985, end = 2020)
 
 out <- SpaDES.project::setupProject(

--- a/globalSK-SCANFI.R
+++ b/globalSK-SCANFI.R
@@ -20,7 +20,6 @@ out <- SpaDES.project::setupProject(
   options = options(
     repos = c(repos = repos),
     Require.cloneFrom = Sys.getenv("R_LIBS_USER"),
-    reproducible.destinationPath = "inputs",
     ## These are for speed
     reproducible.useMemoise = TRUE,
     # Require.offlineMode = TRUE,
@@ -50,7 +49,7 @@ out <- SpaDES.project::setupProject(
   ## define the  study area.
   masterRaster = {
     mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1EIct8OMMdUP3_F0njXyeqIe004TTTtWU/view?usp=drive_link",
-                                   destinationPath = "inputs")
+                                   destinationPath = paths$inputPath)
     mr[mr[] == 0] <- NA
     mr
   },

--- a/globalSK-SCANFI.R
+++ b/globalSK-SCANFI.R
@@ -1,11 +1,14 @@
-projectPath <- "~/GitHub/spadesCBM"
 
 # Install SpaDES.project
 install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
 
+# Set project path
+projectPath <- "~/GitHub/spadesCBM"
+
 # Set times
 times <- list(start = 1985, end = 2020)
 
+# Set up project
 out <- SpaDES.project::setupProject(
   Restart = TRUE,
   useGit = "PredictiveEcology", # a developer sets and keeps this = TRUE

--- a/globalSK-SCANFI.R
+++ b/globalSK-SCANFI.R
@@ -31,7 +31,6 @@ out <- SpaDES.project::setupProject(
                "PredictiveEcology/CBM_vol2biomass@development",
                "PredictiveEcology/CBM_core@development"),
   times = times,
-  require = c("reproducible"),
 
   params = list(
     CBM_defaults = list(
@@ -46,6 +45,8 @@ out <- SpaDES.project::setupProject(
   ),
 
   #### begin manually passed inputs #########################################
+  require = c("reproducible", "data.table", "terra"),
+
   ## define the  study area.
   masterRaster = {
     mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1EIct8OMMdUP3_F0njXyeqIe004TTTtWU/view?usp=drive_link",
@@ -60,10 +61,10 @@ out <- SpaDES.project::setupProject(
   ageDataYear = 2020,
   userGcMeta = as.data.table(reproducible::prepInputs(url = "https://drive.google.com/file/d/1rlygsfT9Te6XHNAKNQxfQJDwMybXLijG/view?usp=drive_link",
                                                       destinationPath = paths$inputPath,
-                                                      fun = fread)),
+                                                      fun = data.table::fread)),
   userGcM3 = as.data.table(reproducible::prepInputs(url = "https://drive.google.com/file/d/12RHUTxQX9yRwgkWKDzWrA3q27FVYU_3h/view?usp=drive_link",
                                                     destinationPath = paths$inputPath,
-                                                    fun = fread)),
+                                                    fun = data.table::fread)),
 
   ## If not using curveID, comment this in.
   # gcIndexLocator = terra::rast("~/GitHub/Data/scanfi/gcIndex.tif"),

--- a/globalSK-SCANFI.R
+++ b/globalSK-SCANFI.R
@@ -49,20 +49,20 @@ out <- SpaDES.project::setupProject(
 
   ## define the  study area.
   masterRaster = {
-    mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1EIct8OMMdUP3_F0njXyeqIe004TTTtWU/view?usp=drive_link",
+    mr <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1EIct8OMMdUP3_F0njXyeqIe004TTTtWU",
                                    destinationPath = paths$inputPath)
     mr[mr[] == 0] <- NA
     mr
   },
 
-  ageLocator = terra::round(reproducible::prepInputs(url = "https://drive.google.com/file/d/1OvloZLpXvx-Wc2Qr4LAgXkweS-u97BE7/view?usp=drive_link",
+  ageLocator = terra::round(reproducible::prepInputs(url = "https://drive.google.com/file/d/1OvloZLpXvx-Wc2Qr4LAgXkweS-u97BE7",
                                                      destinationPath = paths$inputPath,
                                                      fun = terra::rast)),
   ageDataYear = 2020,
-  userGcMeta = as.data.table(reproducible::prepInputs(url = "https://drive.google.com/file/d/1rlygsfT9Te6XHNAKNQxfQJDwMybXLijG/view?usp=drive_link",
+  userGcMeta = as.data.table(reproducible::prepInputs(url = "https://drive.google.com/file/d/1rlygsfT9Te6XHNAKNQxfQJDwMybXLijG",
                                                       destinationPath = paths$inputPath,
                                                       fun = data.table::fread)),
-  userGcM3 = as.data.table(reproducible::prepInputs(url = "https://drive.google.com/file/d/12RHUTxQX9yRwgkWKDzWrA3q27FVYU_3h/view?usp=drive_link",
+  userGcM3 = as.data.table(reproducible::prepInputs(url = "https://drive.google.com/file/d/12RHUTxQX9yRwgkWKDzWrA3q27FVYU_3h",
                                                     destinationPath = paths$inputPath,
                                                     fun = data.table::fread)),
 
@@ -71,10 +71,10 @@ out <- SpaDES.project::setupProject(
 
   ## Comment this out if not using curveID
   curveID = c("speciesId", "prodclass"),
-  leadSpeciesRaster = reproducible::prepInputs(url = "https://drive.google.com/file/d/1EIct8OMMdUP3_F0njXyeqIe004TTTtWU/view?usp=drive_link",
+  leadSpeciesRaster = reproducible::prepInputs(url = "https://drive.google.com/file/d/1EIct8OMMdUP3_F0njXyeqIe004TTTtWU",
                                                destinationPath = paths$inputPath,
                                                fun = terra::rast),
-  siteProductivityRaster = reproducible::prepInputs(url = "https://drive.google.com/file/d/1mPkDfGBNxkYPorUxSog36ayRpeISo8iT/view?usp=drive_link",
+  siteProductivityRaster = reproducible::prepInputs(url = "https://drive.google.com/file/d/1mPkDfGBNxkYPorUxSog36ayRpeISo8iT",
                                                     destinationPath = paths$inputPath,
                                                     fun = terra::rast),
   cohortLocators = list(

--- a/globalSK.R
+++ b/globalSK.R
@@ -1,7 +1,7 @@
 projectPath <- "~/GitHub/spadesCBM"
-repos <- unique(c("predictiveecology.r-universe.dev", getOption("repos")))
-install.packages("SpaDES.project",
-                 repos = repos)
+
+# Install SpaDES.project
+install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
 
 # Set times
 times <- list(start = 1985, end = 2020)
@@ -18,7 +18,7 @@ out <- SpaDES.project::setupProject(
                cachePath   = file.path(projectPath, "cache")),
 
   options = options(
-    repos = c(repos = repos),
+    repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))),
     Require.cloneFrom = Sys.getenv("R_LIBS_USER"),
     ## These are for speed
     reproducible.useMemoise = TRUE,

--- a/globalSK.R
+++ b/globalSK.R
@@ -20,7 +20,6 @@ out <- SpaDES.project::setupProject(
   options = options(
     repos = c(repos = repos),
     Require.cloneFrom = Sys.getenv("R_LIBS_USER"),
-    reproducible.destinationPath = "inputs",
     ## These are for speed
     reproducible.useMemoise = TRUE,
     # Require.offlineMode = TRUE,

--- a/globalSK.R
+++ b/globalSK.R
@@ -1,11 +1,14 @@
-projectPath <- "~/GitHub/spadesCBM"
 
 # Install SpaDES.project
 install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
 
+# Set project path
+projectPath <- "~/GitHub/spadesCBM"
+
 # Set times
 times <- list(start = 1985, end = 2020)
 
+# Set up project
 out <- SpaDES.project::setupProject(
   Restart = TRUE,
   useGit = "PredictiveEcology", # a developer sets and keeps this = TRUE

--- a/globalSK.R
+++ b/globalSK.R
@@ -3,8 +3,8 @@ repos <- unique(c("predictiveecology.r-universe.dev", getOption("repos")))
 install.packages("SpaDES.project",
                  repos = repos)
 
-# start in 1998, and end in 2000
-times <- list(start = 1998, end = 2000)
+# Set times
+times <- list(start = 1985, end = 2020)
 
 out <- SpaDES.project::setupProject(
   Restart = TRUE,

--- a/globalSKsmall.R
+++ b/globalSKsmall.R
@@ -1,7 +1,7 @@
 projectPath <- "~/GitHub/spadesCBM"
-repos <- unique(c("predictiveecology.r-universe.dev", getOption("repos")))
-install.packages("SpaDES.project",
-                 repos = repos)
+
+# Install SpaDES.project
+install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
 
 # Set times
 times <- list(start = 1985, end = 2020)
@@ -18,7 +18,7 @@ out <- SpaDES.project::setupProject(
                cachePath   = file.path(projectPath, "cache")),
 
   options = options(
-    repos = c(repos = repos),
+    repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))),
     Require.cloneFrom = Sys.getenv("R_LIBS_USER"),
     ## These are for speed
     reproducible.useMemoise = TRUE,

--- a/globalSKsmall.R
+++ b/globalSKsmall.R
@@ -20,7 +20,6 @@ out <- SpaDES.project::setupProject(
   options = options(
     repos = c(repos = repos),
     Require.cloneFrom = Sys.getenv("R_LIBS_USER"),
-    reproducible.destinationPath = "inputs",
     ## These are for speed
     reproducible.useMemoise = TRUE,
     # Require.offlineMode = TRUE,

--- a/globalSKsmall.R
+++ b/globalSKsmall.R
@@ -1,11 +1,14 @@
-projectPath <- "~/GitHub/spadesCBM"
 
 # Install SpaDES.project
 install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
 
+# Set project path
+projectPath <- "~/GitHub/spadesCBM"
+
 # Set times
 times <- list(start = 1985, end = 2020)
 
+# Set up project
 out <- SpaDES.project::setupProject(
   Restart = TRUE,
   useGit = "PredictiveEcology", # a developer sets and keeps this = TRUE

--- a/globalSKsmall.R
+++ b/globalSKsmall.R
@@ -3,8 +3,8 @@ repos <- unique(c("predictiveecology.r-universe.dev", getOption("repos")))
 install.packages("SpaDES.project",
                  repos = repos)
 
-# start in 1998, and end in 2000
-times <- list(start = 1998, end = 2000)
+# Set times
+times <- list(start = 1985, end = 2020)
 
 out <- SpaDES.project::setupProject(
   Restart = TRUE,


### PR DESCRIPTION
Proposing a lil' clean up & standardization of our globals but I'm open to other perspectives on whether or not these are good changes. We could cherry pick what we like.

1. [CASFRI and SCANFI global times set from 1985-2020](https://github.com/PredictiveEcology/spadesCBM/commit/e0f22e03ded49916df1133836ba5ec0b4a06fe5a): Some globals were still set to run from 1998-2000 or the times described in the comment differed from the set times.
2. [input path fix](https://github.com/PredictiveEcology/spadesCBM/commit/a5f7223b1d482c5a23d566f90441220f5f92dbf6): We were using a mix of methods to set where inputs set in `setupProject` end up and I opted to go with using `paths$inputPath` where we needed it. This means we don't need to set the `reproducible.destinationPath` option.
3. [repos set without 'repos' variable](https://github.com/PredictiveEcology/spadesCBM/commit/a3412bc2e7fa7907d9e9761b93f718f220d413d6): This might be just a personal preference for me since I sometimes comment out the `install.packages` for SpaDES.project for repeated runs and I find I run into the `repos` variable not being found error a lot. However I thought that setting it more explicitly in the options instead of with an outside variable might be more SpaDES-correct since `setupProject` isn't supposed to reference outside variables as much as possible (as I understand).
4. [required package fix](https://github.com/PredictiveEcology/spadesCBM/commit/b9163ab2e2ed1247790a50be5358c4e3dd753ac2): fixed a couple instances where `require` didn't include all the packages used in project set up.
5. [URLs without viewing suffix](https://github.com/PredictiveEcology/spadesCBM/commit/f24c49bd9bf6c15712e3c9a7046500b77e6ae0c9): Google drive has a URL suffix that specifies to open the file for "viewing" on a browser. Doesn't affect anything - perhaps just slightly "more correct" but effectively just an aesthetic change.
6. [SpaDES.project install moved to top of globals](https://github.com/PredictiveEcology/spadesCBM/commit/cadd0dac438a502014f92f32076fc4c60b8fe918): A suggestion from me based on how I'm used to setting up scripts but perhaps there's a reason (or a custom) to do it the way we do it. Typically all package install & loading occurs at the very top of a script so this just moves that step up above setting the project path. Not married to this one!

Top of every script looks like:

```
# Install SpaDES.project
install.packages("SpaDES.project", repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))

# Set project path
projectPath <- "~/GitHub/spadesCBM"

# Set times
times <- list(start = 1985, end = 2020)

# Set up project
out <- SpaDES.project::setupProject(
...
```